### PR TITLE
Fix setting default name to ConsumeCommand (Symfony 7+) & Amqp decode error

### DIFF
--- a/src/SymfonyBundle/Command/ConsumeCommand.php
+++ b/src/SymfonyBundle/Command/ConsumeCommand.php
@@ -39,7 +39,7 @@ class ConsumeCommand extends Command
         $this->container = $container;
         $this->queueNames = $queueNames;
         $this->logger = $logger ?? new NullLogger();
-        parent::__construct();
+        parent::__construct(static::$defaultName);
     }
 
     protected function configure(): void

--- a/src/Transport/Amqp/Marshaler/StructuredMarshaler.php
+++ b/src/Transport/Amqp/Marshaler/StructuredMarshaler.php
@@ -55,7 +55,7 @@ final class StructuredMarshaler implements MarshalerInterface
         }
 
         try {
-            $body = json_encode($event, JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT);
+            $body = json_encode($event, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new UnprocessableEventException('Failed to encode CloudEvents JSON: ' . $e->getMessage(), previous: $e);
         }
@@ -124,7 +124,7 @@ final class StructuredMarshaler implements MarshalerInterface
         // Extract data
         if (isset($event['data'])) {
             try {
-                $data = json_encode($event['data'], JSON_THROW_ON_ERROR);
+                $data = json_encode($event['data'], JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT);
             } catch (JsonException $e) {
                 throw new UnprocessableEventException('Failed to encode data: ' . $e->getMessage(), previous: $e);
             }

--- a/src/Transport/Amqp/Marshaler/StructuredMarshaler.php
+++ b/src/Transport/Amqp/Marshaler/StructuredMarshaler.php
@@ -55,7 +55,7 @@ final class StructuredMarshaler implements MarshalerInterface
         }
 
         try {
-            $body = json_encode($event, JSON_THROW_ON_ERROR);
+            $body = json_encode($event, JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT);
         } catch (JsonException $e) {
             throw new UnprocessableEventException('Failed to encode CloudEvents JSON: ' . $e->getMessage(), previous: $e);
         }


### PR DESCRIPTION
1) Add defaultName to parent constructor call in Consume command.

Symfony v7+ wants either attribute AsCommand or set name in constructor argument of Symfony\Component\Console\Command\Command.
https://github.com/symfony/symfony/blob/7.0/src/Symfony/Component/Console/Command/Command.php#L59

Without this, we got this error:
```
bin/console protoevent:consume
                                                                                                                        
 [WARNING] Some commands could not be registered:                                                                                                                                                                                                                                                                                                                
  The command defined in "QuarksTech\ProtoEvent\SymfonyBundle\Command\ConsumeCommand" cannot have an empty name.
```

That was not the case in previous versions, because static property was still in use (with deprecation notice). In 7 version this behavior was removed.
https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Console/Command/Command.php#L85
___________________________________________________________________________________________________

2) Problems with decoding JSON to proto message. 
For empty nested object in data, after json_decode and then encode again - code transforms empty arrays as []. Protobuf wants {}.
<img width="976" height="432" alt="Screenshot 2026-03-04 at 15 37 14" src="https://github.com/user-attachments/assets/3d938579-f082-49b9-82d1-d5e50c31a7bd" />




Later in QuarksTech\ProtoEvent\Encoding\JsonCodec code fails with error in current implementation.
<img width="797" height="526" alt="Screenshot 2026-03-04 at 15 47 11" src="https://github.com/user-attachments/assets/e926dc4f-ca7e-4012-b800-28c121a8ac55" />

Added JSON_FORCE_OBJECT option in `AMQP\Marshaller\StructuredMarshaller::unmarshal` to fix this.
